### PR TITLE
Remove sudo in torchvision install

### DIFF
--- a/utils/install_dependencies.sh
+++ b/utils/install_dependencies.sh
@@ -17,7 +17,7 @@ python3 -m pip install --no-cache $TORCH_INSTALL --upgrade
 echo "Installing TorchVision CUDA"
 git clone -b v0.14.0 https://github.com/pytorch/vision torchvision-0140
 pushd torchvision-0140
-sudo python3 setup.py install
+python3 setup.py install --user
 popd
 rm -rf torchvision-0140
 


### PR DESCRIPTION
Hello @rams16592 @kvnsng,

We need to install `torchvision` to current "--user" and remove "sudo", or otherwise the below error can be seen.

```sh
Traceback (most recent call last):
  File "setup.py", line 9, in <module>
    import torch
ModuleNotFoundError: No module named 'torch'
```

It is also mentioned [here](https://forums.developer.nvidia.com/t/pytorch-for-jetson/72048).

![image](https://github.com/aws-samples/deploy-yolov8-on-edge-using-aws-iot-greengrass/assets/20147381/0c6199e9-3de9-48fb-9fd9-3c3503f0312a)
